### PR TITLE
HTTP mirroring: don't follow http redirects

### DIFF
--- a/mirror/modules/sink/http.go
+++ b/mirror/modules/sink/http.go
@@ -83,6 +83,9 @@ func NewHTTP(ctx *mirror.ModuleContext, cfg []byte) (mirror.Module, error) {
 		out:   make(chan mirror.Request),
 		tasks: make(chan mirror.Request),
 		client: &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 			Timeout: timeout,
 		},
 		maxWorkers: maxWorkers,


### PR DESCRIPTION
We don't want to do anything else than sending the HTTP query to the
mirrored URL, so prevent Go's HTTP client to follow redirects, which is
the default behavior.