### PR TITLE
Enable dependabot to auto-update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5


### PR DESCRIPTION
We don't want to have to update dependencies manually, this automates it.