### PR TITLE
build: use tags=netgo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           fi
 
       - name: Build
-        run: go build -v -ldflags "-linkmode external -extldflags -static" .
+        run: go build -v -ldflags "-linkmode external -extldflags -static" -tags=netgo .
 
 
       - uses: "marvinpinto/action-automatic-releases@latest"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         fi
 
     - name: Build
-      run: go build -v -ldflags "-linkmode external -extldflags -static" .
+      run: go build -v -ldflags "-linkmode external -extldflags -static" -tags=netgo .
 
     - name: Test
       run: go test -v .


### PR DESCRIPTION
This aims to prevent segmentation faults when running with
different glibc version.